### PR TITLE
Integrate cocoapods push into CI flow via circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,5 @@
 version: 2
 jobs:
-  dummy:
-    docker:
-        - image: circleci/ruby:2.6.2
-    steps:
-      - run:
-          name: "test"
-          command: "echo string"
-          
   release:
     docker:
         - image: circleci/ruby:2.6.2
@@ -35,8 +27,6 @@ workflows:
   version: 2
   release_flow:
     jobs:
-        - dummy
-
         - approve_release:
             type: approval
         - release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,12 @@
 version: 2
 jobs:
+  dummy:
+    docker:
+        - image: circleci/ruby:2.6.2
+    steps:
+      - run:
+          name: "test"
+          command: "echo string"
   release:
     docker:
         - image: circleci/ruby:2.6.2
@@ -27,6 +34,8 @@ workflows:
   version: 2
   release_flow:
     jobs:
+        - dummy:
+
         - approve_release:
             type: approval
         - release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,5 +29,7 @@ workflows:
     jobs:
         - approve_release:
             type: approval
-        - release
+        - release:
+            requires:
+                - approve_release
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
       - run:
           name: "test"
           command: "echo string"
+          
   release:
     docker:
         - image: circleci/ruby:2.6.2
@@ -34,7 +35,7 @@ workflows:
   version: 2
   release_flow:
     jobs:
-        - dummy:
+        - dummy
 
         - approve_release:
             type: approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             - "vendor/bundle"
       - run:
           name: "Release public sdk"
-          command: "DRY_RUN=yes bundle exec rake release"
+          command: "bundle exec rake release"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - add_ssh_keys:
           fingerprints:
-            - "d9:46:1f:1f:ef:ca:9e:2a:a2:b8:c0:ce:d7:aa:9b:57"
+            - "a2:58:29:01:f0:5e:a7:49:63:86:c3:b9:0e:d6:af:0f"
       - checkout:
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,33 @@
+version: 2
+jobs:
+  release:
+    docker:
+        - image: circleci/ruby:2.6.2
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "d9:46:1f:1f:ef:ca:9e:2a:a2:b8:c0:ce:d7:aa:9b:57"
+      - checkout:
+      - restore_cache:
+          keys:
+            - gem-cache-v2-{{ checksum "Gemfile.lock" }}
+            - gem-cache-v2-
+      - run:
+          name: "Bundle install"
+          command: "bundle install --path vendor/bundle"
+      - save_cache:
+          key: gem-cache-v2-{{ checksum "Gemfile.lock" }}
+          paths:
+            - "vendor/bundle"
+      - run:
+          name: "Release public sdk"
+          command: "DRY_RUN=yes bundle exec rake release"
+
+workflows:
+  version: 2
+  release_flow:
+    jobs:
+        - approve_release:
+            type: approval
+        - release
+

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,4 @@ gem 'rake'
 gem 'octokit'
 gem 'pry'
 
-gem 'sdk-ci', git: 'git@github.com:tenjin/sdk-ci-gem'
+gem 'sdk-ci', git: 'https://github.com/tenjin/sdk-ci-gem.git'

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ gem 'cocoapods'
 gem 'rake'
 gem 'octokit'
 gem 'pry'
+
+gem 'sdk-ci', git: 'git@github.com:tenjin/sdk-ci-gem'

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+source 'https://rubygems.org'
+
 gem 'cocoapods'
 gem 'rake'
 gem 'octokit'

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source 'https://rubygems.org'
 gem 'cocoapods'
 gem 'rake'
 gem 'octokit'
-gem 'pry'
+gem 'pry-byebug'
 
 gem 'sdk-ci', git: 'git@github.com:tenjin/sdk-ci-gem'

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,4 @@ gem 'rake'
 gem 'octokit'
 gem 'pry'
 
-gem 'sdk-ci', git: 'https://github.com/tenjin/sdk-ci-gem.git'
+gem 'sdk-ci', git: 'git@github.com:tenjin/sdk-ci-gem'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
-  remote: https://github.com/tenjin/sdk-ci-gem.git
-  revision: 4f22d12a991b736b1780d3a0ecc82dc53d6f88e7
+  remote: git@github.com:tenjin/sdk-ci-gem
+  revision: 44798733d590cbd28c1f71e759e5b20dcb8c617b
   specs:
     sdk-ci (0.1.0)
       faraday (~> 0.15)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git@github.com:tenjin/sdk-ci-gem
-  revision: 44798733d590cbd28c1f71e759e5b20dcb8c617b
+  revision: b4c4d0e47b7040758498e9ea6ad40ded7dc3efd2
   specs:
     sdk-ci (0.1.0)
       faraday (~> 0.15)
@@ -16,9 +16,10 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    addressable (2.5.2)
-      public_suffix (>= 2.0.2, < 4.0)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     atomos (0.1.3)
+    byebug (11.0.1)
     claide (1.0.2)
     cocoapods (1.6.1)
       activesupport (>= 4.0.2, < 5)
@@ -57,7 +58,7 @@ GEM
     colored2 (3.1.2)
     concurrent-ruby (1.1.5)
     escape (0.0.4)
-    faraday (0.15.4)
+    faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
     fourflusher (2.2.0)
     fuzzy_match (2.0.4)
@@ -67,21 +68,25 @@ GEM
     method_source (0.9.2)
     minitest (5.11.3)
     molinillo (0.6.6)
-    multipart-post (2.0.0)
+    multipart-post (2.1.1)
     nanaimo (0.2.6)
     nap (1.1.0)
     netrc (0.11.0)
-    octokit (4.14.0)
+    octokit (4.15.0)
+      faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    public_suffix (2.0.5)
+    pry-byebug (3.7.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
+    public_suffix (4.0.3)
     rake (12.3.2)
     ruby-macho (1.4.0)
-    sawyer (0.8.1)
-      addressable (>= 2.3.5, < 2.6)
-      faraday (~> 0.8, < 1.0)
+    sawyer (0.8.2)
+      addressable (>= 2.3.5)
+      faraday (> 0.8, < 2.0)
     thor (0.20.3)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -99,7 +104,7 @@ PLATFORMS
 DEPENDENCIES
   cocoapods
   octokit
-  pry
+  pry-byebug
   rake
   sdk-ci!
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: git@github.com:tenjin/sdk-ci-gem
+  revision: 4f22d12a991b736b1780d3a0ecc82dc53d6f88e7
+  specs:
+    sdk-ci (0.1.0)
+      faraday (~> 0.15)
+      octokit (~> 4.14)
+      thor (~> 0.20)
+
 GEM
   specs:
     CFPropertyList (3.0.0)
@@ -72,6 +81,7 @@ GEM
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
+    thor (0.20.3)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
@@ -90,6 +100,7 @@ DEPENDENCIES
   octokit
   pry
   rake
+  sdk-ci!
 
 BUNDLED WITH
    1.17.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git@github.com:tenjin/sdk-ci-gem
+  remote: https://github.com/tenjin/sdk-ci-gem.git
   revision: 4f22d12a991b736b1780d3a0ecc82dc53d6f88e7
   specs:
     sdk-ci (0.1.0)
@@ -8,6 +8,7 @@ GIT
       thor (~> 0.20)
 
 GEM
+  remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.0)
     activesupport (4.2.11.1)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,7 @@
-Please see our [Release Notes](https://github.com/tenjin/tenjin-ios-sdk/wiki) to see detailed version history.
+> For Unity-specific instructions, please visit https://github.com/tenjin/tenjin-unity-sdk.
 
-For Unity instructions, please visit https://github.com/tenjin/tenjin-unity-sdk.
-
-For CocoaPods instructions, please visit https://cocoapods.org/pods/TenjinSDK.
-
-Tenjin iOS SDK (v1.9.1) (268KB) (Deployment Version 6.0+)
+Tenjin iOS SDK v1.9.1
 ==============
-Note: We recommend using the latest version of <a href="https://developer.apple.com/xcode/">Xcode</a> when integrating our SDK.
 
 Tenjin initialization:
 -------------------------------

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-> For Unity-specific instructions, please visit https://github.com/tenjin/tenjin-unity-sdk.
-
 Tenjin iOS SDK v1.9.1
 ==============
+
+The native iOS SDK for Tenjin. Integrate this into your iOS app or game to get access to the functionality offered at https://www.tenjin.com/.
+
+> If you're using Unity, please take a look at our Unity SDK at https://github.com/tenjin/tenjin-unity-sdk for an easier integration and C# API
+
+> Check out the [release notes](RELEASE_NOTES.md) for a detailed version history
 
 Tenjin initialization:
 -------------------------------

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,210 @@
+v1.0.0
+----
+- First release to measure app opens and installs
+
+v1.0.1
+----
+- Bundle requirements into `.a` lib
+- Include custom events
+- Fix bugs
+- Include SDK Versioning
+
+v1.0.2
+----
+- Include receipt validation => use StoreKit API to validate and pass transactions to Tenjin Server
+- Standardize revenue event capture => Allow users to send revenue events manually (ProductID, Currency Locale, Quantity, Price). They can also send us a SKPaymentTransaction where we send our server the following on our own. Need to figure out a way to check and validate receipts.
+- Change GET requests to POST
+
+v1.1.0
+----
+- Add `device` parameter to request
+- iAd attribution to pass `iad` and `iad_impression_ts` => requires developer to include iAd.framework
+
+v1.1.1
+----
+- Update to build version 7.0
+
+v1.1.2
+----
+- Update to build 6.0
+
+v1.1.3
+----
+- Update settings to make iOS9 easier
+
+v1.1.4
+----
+- Now compiles with bitcode enabled & embedded
+
+v1.2.0
+----
+- Check to make sure eventValue for custom events is an integer
+
+v1.3.0
+----
+- Pass `receipt` to server to validate transaction
+- Deprecate just accepting SKPaymentTransaction. If you pass SKPaymentTransaction we will also require a receipt
+- Pass `transaction_id` to server
+- Refactor 
+
+v.1.3.1
+----
+- Allow manual transaction call for that accepts a `transaction_id` and `receipt` for receipt validation
+- Set up to allow Unity to have receipt validation
+
+v1.4.0
+----
+- Use SFSafariViewController in iOS9 to capture cookies for accurate web to app tracking. No longer require IP Address to match web to app fingerprinted installs
+- DRY up device params methods
+- Fix SDK Demo app
+
+v1.4.1
+----
+- Fix SFSafariViewController with time delay to make cookie tracking more accurate
+
+v1.4.2
+----
+- Add vendor ID
+
+v1.4.3
+----
+- Remove deprecated iAd network code
+
+v1.4.4
+----
+- Reduce view controller time for cookie tracking
+- Ignore cookie tracking for iOS10 based on beta testing
+
+v1.4.5
+----
+- Reduce view controller time to 0.5s
+
+v1.4.6
+----
+- Reduce view controller time to 0.05s
+- Add better comments to SDK methods
+
+v1.4.7
+----
+- Go back to zero delay in cookie tracking for viewcontroller. Don't need to worry about deleting the cookie on app open. 
+
+v1.4.8
+----
+- Make OS version check compatible for versions < iOS8
+
+v1.4.9
+----
+- Take out SFSafariViewController for tracking cookies -> Apple is not allowing it per section 5.1.1 (iv) https://developer.apple.com/app-store/review/guidelines/#data-collection-and-storage
+
+v1.5.0
+----
+- Include Apple Search Ads attribution
+
+v1.5.1
+----
+- Allow users to pass in base64 receipts for receipt validation on purchases
+
+v1.5.2
+----
+- Allow developers to use bitcode for their apps
+
+v1.5.3
+----
+- Update for most recent Apple API calls
+
+v1.6.0
+----
+- Update connection URL logic to session HTTP logic for recent Apple SDK calls
+- Deferred Deeplink URL logic (beta)
+
+v1.7.0
+----
+- Allow developer to pass a deferred deeplink into Tenjin
+
+v1.7.1
+----
+- Update for NSSession threading issues
+
+v1.7.2
+----
+- Update SDK to always fire handler callback
+
+v1.7.3
+----
+- Add retry logic for `getUser` if not 200/202 error
+
+v1.7.4
+----
+- Add App Device User Agent params
+
+v1.7.4
+----
+- Add App Device User Agent params
+
+v1.7.5
+----
+- Add GDPR Support
+
+v1.7.6
+----
+- Update GDPR Support
+
+v1.7.7
+----
+- Fix GDPR bug
+
+v1.7.4
+----
+- Add App Device User Agent params
+
+v1.7.5
+----
+- Add GDPR Support
+
+v1.7.6
+----
+- Update GDPR Support
+
+v1.7.7
+----
+- Fix GDPR bug
+
+v1.7.8
+----
+- Version bump for Cordova
+
+v1.7.9
+----
+- Fix NSInvalidArgumentException bug
+
+v1.8.2
+----
+- Add App Subversion method
+
+v1.9.1
+----
+- Create getInstance() alternative to init() for Swift 5 support
+
+v1.9.2
+----
+- Use circle ci to build and release
+
+v1.10.1
+---
+- Integrate MoPub Impression Level Revenue
+
+v1.10.2
+---
+
+- CI unification
+
+v1.10.3
+---
+
+- New logger
+- Bugfix for duplicate ILRD events under unity
+
+v1.11.0
+----
+- Send wrapper sdk version prepended to sdk_version
+

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,5 @@
-require 'pry'
+require 'pry-byebug'
 require 'octokit'
-require 'tmpdir'
 require 'sdk/ci'
 
 REPO_NAME = "tenjin/tenjin-ios-sdk"
@@ -74,7 +73,6 @@ def update_readme version
 end
 
 def push_github_release version, description
-  binding.pry
 
   Sdk::Ci::Github.push_release REPO_NAME, version, description, RELEASE_ASSETS unless ENV["DRY_RUN"]
 end
@@ -90,6 +88,7 @@ task :release do
   commit_and_tag tag
   push_github_release tag, notes
 
-  push_pod()
+  #this execs the process and must be called last
+  push_pod
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require 'pry'
 require 'octokit'
 require 'tmpdir'
+require 'sdk/ci'
 
 INTERNAL_REPO = "tenjin/ios-sdk"
 
@@ -30,12 +31,27 @@ def push_pod
 
 end
 
-desc "Get new release assets and publish"
-task :release do
-  version, assets, notes = get_release
+def update_release_notes tag
 
-  update_pod(version)
-  commit_and_tag(version)
+end
+
+def update_readme version
+  title_regex = /Tenjin iOS SDK v\d+\.\d+\.\d+/
+
+  #write out version in readme
+  Sdk::Ci::Util.replace_line_in_file "README.md", title_regex, "Tenjin iOS SDK v#{version}"
+end
+
+desc "Get new release assets, update details and publish"
+task :release do
+  tag, assets, notes = get_release
+
+  update_readme tag
+  update_release_notes tag
+  update_pod tag
+
+  commit_and_tag tag
+
   push_pod()
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -4,15 +4,18 @@ require 'tmpdir'
 require 'sdk/ci'
 
 INTERNAL_REPO = "tenjin/ios-sdk"
+INTERNAL_REPO_RELEASE_NOTES = "README.md"
+
+RELEASE_NOTES = "RELEASE_NOTES.md"
 
 def get_release
-  client = Octokit::Client.new(access_token: ENV["GITHUB_TOKEN"])
+  @client = Octokit::Client.new(access_token: ENV["GITHUB_TOKEN"])
 
-  release = client.latest_release INTERNAL_REPO
+  release = @client.latest_release INTERNAL_REPO
   notes, version, assets = release[:body], release[:tag_name], release[:assets]
 
   assets.each do |a|
-    f = client.release_asset(a[:url], accept: "application/octet-stream")
+    f = @client.release_asset(a[:url], accept: "application/octet-stream")
     File.open(a[:name],"wb"){|file| file << f}
   end
 
@@ -32,7 +35,18 @@ def push_pod
 end
 
 def update_release_notes tag
+  file = @client.contents INTERNAL_REPO, path: INTERNAL_REPO_RELEASE_NOTES, ref: tag
 
+  #extract file contents and remove newlines
+  file_contents = file[:content].lines.map(&:chomp).join
+
+  #decode into array of utf8 string
+  file_text = Base64.decode64(file_contents).lines
+
+  #remove until we get to the first release description
+  release_notes = file_text.drop_while {|l| not l =~ /^v\d+\.\d+\.\d+/ }
+
+  File.open(RELEASE_NOTES,"w") {|f| f << release_notes.join }
 end
 
 def update_readme version
@@ -48,6 +62,7 @@ task :release do
 
   update_readme tag
   update_release_notes tag
+
   update_pod tag
 
   commit_and_tag tag

--- a/TenjinSDK.podspec
+++ b/TenjinSDK.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
                    Tenjin is a unique growth infrastructure platform that helps you streamline your mobile marketing.
                    DESC
 
-  s.homepage     = "https://tenjin.io"
+  s.homepage     = "https://tenjin.com"
   s.license      = { :type => 'MIT', :text => <<-LICENSE
                       The MIT License (MIT)
 
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
                       LICENSE
                   }
 
-  s.author       = { "Tenjin" => "engineering@tenjin.io" }
+  s.author       = { "Tenjin" => "engineering@tenjin.com" }
   s.platform     = :ios, "6.0"
 
   s.source       = { :git => "https://github.com/tenjin/tenjin-ios-sdk.git", :tag => "#{s.version}" }


### PR DESCRIPTION
This review modifies the current CI + release process in a few ways.

* The podspec for cocoapods is updated with the latest version number and pushed to trunk
* Release notes are pulled in via the README from tenjin/ios-sdk
* README is updated on release to include the latest version number
* CircleCI config to perform the above tasks

With this it should be possible to trigger a build upon a release of the internal repository, making a public release a simple matter of navigating to circleci and approving the workflow.