### PR TITLE
Use the absolute file path for iOS SDK docs [TENJIN-5607]

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ The native iOS SDK for Tenjin. Integrate this into your iOS project to get acces
   - `iAd.framework`
   - `StoreKit.framework`
 
-![Dashboard](assets/ios_link_binary.png?raw=true "dashboard")
+![Dashboard](https://github.com/tenjin/tenjin-ios-sdk/blob/master/assets/ios_link_binary.png?raw=true "dashboard")
 
 
 ##### 4. Include the linker flags `-ObjC` under your Build Settings
-![Dashboard](assets/ios_linker_flags.png?raw=true "dashboard")
+![Dashboard](https://github.com/tenjin/tenjin-ios-sdk/raw/master/assets/ios_linker_flags.png?raw=true "dashboard")
 
 
 ##### 5. Go to your AppDelegate file, by default `AppDelegate.m`, and `#import "TenjinSDK.h"`.


### PR DESCRIPTION
**JIRA**:

- https://adromance.atlassian.net/browse/TENJIN-5607

**Proposed Changes:**

- Use absolute file path for the image files, so that the image shows up properly in docs page

https://adromance.slack.com/archives/CAC4H4P4J/p1600700856020700

**Steps:**

- [ ] Reviewed
- [ ] Deployed
