### PR TITLE
Provide guidelines for custom event name length and cardinality [TENJIN-7035]

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,8 @@ For more information on subscriptions, please see: <a href="https://developer.ap
 ## Tenjin custom event integration instructions:
 **IMPORTANT: DO NOT SEND CUSTOM EVENTS BEFORE THE CONNECT/INITIALIZATION** event (above). The initialization must come before any custom events are sent.
 
+**IMPORTANT: Limit custom event names to less than 80 characters. Do not exceed 500 unique custom event names.**
+
 You can also use the Tenjin SDK to pass a custom event:
 - ```sendEventWithName: (NSString *)eventName``` and
 


### PR DESCRIPTION
**JIRA**:

- https://adromance.atlassian.net/browse/TENJIN-7035

**Proposed Changes:**

- Technically these numbers (80 chars / 500 unique vals) aren't actually limitations in our code -- currently, the real limitation for chars is 255 and we don't cap the cardinality. But too high of a cardinality can break some of our sidekiq jobs (and likely slows reporting down as well)
- See [this slack thread](https://adromance.slack.com/archives/C01JED4EJ3T/p1609884178023100) (and its channel) for discussion and/or confirmation that these numbers makes sense.

**Steps:**

- [ ] Reviewed
- [ ] Deployed
