### PR TITLE
docs: clarify subscription tracking requires explicit method call [TENJIN-29028]

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,8 @@ For more information on subscriptions, please see: <a href="https://developer.ap
 
 Track subscription purchases with Tenjin for server-side verification and attribution. See [SUBSCRIPTIONS_TRACKING.md](SUBSCRIPTIONS_TRACKING.md) for the full guide, including integration examples with StoreKit 2 and RevenueCat.
 
+**Subscription tracking is opt-in and is not automatic just from initializing/connecting the SDK.** You must explicitly call one of `subscription(withProductName:...)`, `subscriptionWithStoreKit(forProductId:...)`, or `purchasesManager().subscription(_:)` from your StoreKit 2 purchase-handling code. If general events are showing up on the dashboard but subscription events are not, this is the most common cause.
+
 Pass all SK2 transaction data manually:
 
 ```swift

--- a/SUBSCRIPTIONS_TRACKING.md
+++ b/SUBSCRIPTIONS_TRACKING.md
@@ -2,6 +2,10 @@
 
 Track subscription purchases with Tenjin for server-side verification and attribution.
 
+> **Subscription tracking is opt-in.** Connecting/initializing the SDK does **not** automatically capture subscription or purchase events. You must explicitly call one of the methods below from your StoreKit 2 purchase-handling code.
+>
+> **Troubleshooting:** if general events (session, custom events, etc.) are arriving on the dashboard but subscription events are not, this is the most common cause. Check that one of the methods below is actually being called at purchase time.
+
 ## Methods
 
 ### `subscription(withProductName:...)` — Manual Parameters


### PR DESCRIPTION
## Summary
Recurring support pattern: customers integrate the SDK, confirm they are on the latest version, but never see subscription events on the dashboard. Root cause is that subscription tracking is opt-in and requires an explicit call to one of the subscription methods from StoreKit 2 purchase-handling code.

- Add an opt-in callout near the top of SUBSCRIPTIONS_TRACKING.md, plus a troubleshooting note for the "general events arrive, subscription events do not" case.
- Add the same callout to the README's Subscription Tracking section.

## Test plan
- Docs only change, no code affected.
- Rendered both files locally to confirm markdown formatting.

Jira: TENJIN-29028